### PR TITLE
Fix/login and redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.swp 
 *~.nib 
 *.tmp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This plugin allows single sign-on (SSO) authentication in Moodle from an externa
 
 ---
 
+## 🔀 Fork Changes
+
+This fork modifies `login.php` with two changes from [the original](https://github.com/richardg7/moodle-local_ssologin):
+
+1. **Removed `require_login()`** — The original plugin redirects (303) users who are not already logged in, which prevents SSO from working. This fork allows unauthenticated users to reach the SSO endpoint so they can log in via the external system.
+
+2. **Optional `redirect` parameter** — After successful SSO login, you can pass a `redirect` query parameter (URL) to send the user to a specific page instead of the Moodle home. Example: `.../login.php?data=...&sig=...&redirect=https://example.com/course/view.php?id=123`
+
+---
+
 ## 🚀 Installation
 
 1. Access Moodle as **administrator**

--- a/README.md
+++ b/README.md
@@ -4,16 +4,6 @@ This plugin allows single sign-on (SSO) authentication in Moodle from an externa
 
 ---
 
-## 🔀 Fork Changes
-
-This fork modifies `login.php` with two changes from [the original](https://github.com/richardg7/moodle-local_ssologin):
-
-1. **Removed `require_login()`** — The original plugin redirects (303) users who are not already logged in, which prevents SSO from working. This fork allows unauthenticated users to reach the SSO endpoint so they can log in via the external system.
-
-2. **Optional `redirect` parameter** — After successful SSO login, you can pass a `redirect` query parameter (URL) to send the user to a specific page instead of the Moodle home. Example: `.../login.php?data=...&sig=...&redirect=https://example.com/course/view.php?id=123`
-
----
-
 ## 🚀 Installation
 
 1. Access Moodle as **administrator**

--- a/login.php
+++ b/login.php
@@ -26,11 +26,6 @@ require('../../config.php');
 require_once($CFG->libdir . '/authlib.php');
 require_once(__DIR__.'/locallib.php');
 
-// Ensure the user is logged in or has appropriate permissions.
-// START EXTREME EDIT - original code will 303 redirect if a user is not already logged in. Makes the plugin a bit pointless if you can't proceed.
-// require_login();
-// END EXTREME EDIT
-
 $secret = get_config('local_ssologin', 'secretkey');
 $tokenexpire = get_config('local_ssologin', 'tokenexpire');
 
@@ -54,11 +49,9 @@ if ($user = $DB->get_record('user', ['username' => $username, 'deleted' => 0])) 
     complete_user_login($user);
     local_ssologin_log_attempt('success', $user->id, $username);
 
-    // START EXTREME EDIT - redirect back to the origin if a redirect query string parameter is provided
     if ($redirectQuery = optional_param('redirect', null, PARAM_URL)) {
         redirect($redirectQuery);
     }
-    // END EXTREME EDIT
 
     redirect(new moodle_url('/'));
 } else {

--- a/login.php
+++ b/login.php
@@ -51,7 +51,16 @@ $username = $payload['username'];
 if ($user = $DB->get_record('user', ['username' => $username, 'deleted' => 0])) {
     complete_user_login($user);
     local_ssologin_log_attempt('success', $user->id, $username);
-    redirect(new moodle_url('/'));
+
+    $redirectUrl = new moodle_url('/');
+    if (!empty($payload['redirect'])) {
+        $redirectParam = clean_param($payload['redirect'], PARAM_URL);
+        if (!empty($redirectParam)) {
+            $redirectUrl = new moodle_url($redirectParam);
+        }
+    }
+
+    redirect($redirectUrl);
 } else {
     local_ssologin_log_attempt('fail', 0, $username);
     throw new moodle_exception('loginfailure', 'local_ssologin', '', $username);

--- a/login.php
+++ b/login.php
@@ -27,7 +27,9 @@ require_once($CFG->libdir . '/authlib.php');
 require_once(__DIR__.'/locallib.php');
 
 // Ensure the user is logged in or has appropriate permissions.
-require_login();
+// START EXTREME EDIT - original code will 303 redirect if a user is not already logged in. Makes the plugin a bit pointless if you can't proceed.
+// require_login();
+// END EXTREME EDIT
 
 $secret = get_config('local_ssologin', 'secretkey');
 $tokenexpire = get_config('local_ssologin', 'tokenexpire');
@@ -52,15 +54,13 @@ if ($user = $DB->get_record('user', ['username' => $username, 'deleted' => 0])) 
     complete_user_login($user);
     local_ssologin_log_attempt('success', $user->id, $username);
 
-    $redirectUrl = new moodle_url('/');
-    if (!empty($payload['redirect'])) {
-        $redirectParam = clean_param($payload['redirect'], PARAM_URL);
-        if (!empty($redirectParam)) {
-            $redirectUrl = new moodle_url($redirectParam);
-        }
+    // START EXTREME EDIT - redirect back to the origin if a redirect query string parameter is provided
+    if ($redirectQuery = optional_param('redirect', null, PARAM_URL)) {
+        redirect($redirectQuery);
     }
+    // END EXTREME EDIT
 
-    redirect($redirectUrl);
+    redirect(new moodle_url('/'));
 } else {
     local_ssologin_log_attempt('fail', 0, $username);
     throw new moodle_exception('loginfailure', 'local_ssologin', '', $username);


### PR DESCRIPTION
Hey, thanks for the plugin, I'm not a moodle dev so let me know if this is unsuitable, but the plugin seems to work after these changes.

## Changes

This change modifies `login.php` with two changes:

1. **Removed `require_login()`** — The original plugin would redirects (303) users who are not already logged in, which prevents the logic from working. This change allows unauthenticated users to reach the endpoint allowing the logic to continue and process their login with their encrypted credentials.

2. **Optional `redirect` parameter** — Allowing a `redirect` query parameter (URL) to send the user to a specific page instead of the Moodle home after logging in. Example: `.../login.php?data=...&sig=...&redirect=https://example.com/dashboard`
